### PR TITLE
LTE message parsing

### DIFF
--- a/output.c
+++ b/output.c
@@ -255,7 +255,7 @@ void net_send_msg(struct radio_message *m)
 			msgb = gsmtap_makemsg_ex(0x0e, m->bb.arfcn[0], 0,
 					 0, 0, 0, 0, 0, m->bb.data, m->msg_len);
 		} else if (m->flags & MSG_BCCH) {
-			msgb = gsmtap_makemsg_ex(0x0d, m->bb.arfcn[0], 0,
+			msgb = gsmtap_makemsg_ex(GSMTAP_TYPE_LTE_RRC, m->bb.arfcn[0], 0,
 					 m->chan_nr, 0, 0, 0, 0, m->bb.data, m->msg_len);
 		} else {
 			/* no other types defined */


### PR DESCRIPTION
Finds the size and copies to the LTE message from the diag structure. Up/down flag of RRC message looks better now.
Uses newly defined gsmtap type for LTE RRC